### PR TITLE
Fix a revisit bug

### DIFF
--- a/addOns/revisit/src/main/java/org/zaproxy/zap/extension/revisit/ExtensionRevisit.java
+++ b/addOns/revisit/src/main/java/org/zaproxy/zap/extension/revisit/ExtensionRevisit.java
@@ -210,7 +210,7 @@ public class ExtensionRevisit extends ExtensionAdaptor implements ProxyListener 
 
                     for (int i = 1; i <= node.getHistoryReference().getHistoryId(); i++) {
                         HistoryReference hr = extHist.getHistoryReference(i);
-                        if (hr.getHistoryType() == HistoryReference.TYPE_PROXIED
+                        if (hr != null && hr.getHistoryType() == HistoryReference.TYPE_PROXIED
                                 && isSimilarRequest(url, hr.getURI().toString())) {
                             if (!url.equals(hr.getURI().toString())) {
                                 // We dont perform an exact match above so that we can


### PR DESCRIPTION
## Overview
`hr` is not checked before use, would cause `onHttpRequestSend` failed, then the revisit would fail.

## Related Issues
Specify any related issues or pull requests by linking to them.

## Checklist
- [ ] Update help
- [ ] Update changelog
- [ ] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [ ] Sign-off commits
- [ ] Squash commits
- [ ] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
